### PR TITLE
Change talks order

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -332,33 +332,6 @@
 
                         <!-- Image -->
                         <div class="service-circle">
-                             <img src="images/rails.png" alt="" />
-                        </div>
-
-                        <!-- Text content + "more" button -->
-                        <div class="service-teaser">
-                             <div class="service-description">
-                                  <h3>Building APIs on Rails 5 with AMS</h3>
-                                  <p>
-                                  A lot of people have being using Rails to develop both their internal or external API, but building a high quality API can be hard....
-                                  </p>
-                             </div>
-                             <div class="service-more">
-                                  <a href="#building-apis-rails-5"><h3>More Info</h3></a>
-                                  <a href="https://plus.google.com/events/cm0vmbq6bdcif7sitba8qv5rscc" target="_blank" class="call-to-button scroll">Click to Watch</a>
-                             </div>
-                        </div>
-
-                  </div>
-              </li>
-              <!-- End: 3nd Remote Talk -->
-
-              <!-- 4th Remote Talk -->
-              <li class="wow fadeInUp">
-                  <div class="service-content">
-
-                        <!-- Image -->
-                        <div class="service-circle">
                              <img src="images/elm.png" alt="" />
                         </div>
 
@@ -373,6 +346,33 @@
                              <div class="service-more">
                                   <a href="#intro-frp-elm"><h3>More Info</h3></a>
                                   <a href="https://www.youtube.com/watch?v=bx3mOTGRvs4" target="_blank" class="call-to-button scroll">Click to Watch</a>
+                             </div>
+                        </div>
+
+                  </div>
+              </li>
+              <!-- End: 3nd Remote Talk -->
+
+              <!-- 4th Remote Talk -->
+              <li class="wow fadeInUp">
+                  <div class="service-content">
+
+                        <!-- Image -->
+                        <div class="service-circle">
+                             <img src="images/rails.png" alt="" />
+                        </div>
+
+                        <!-- Text content + "more" button -->
+                        <div class="service-teaser">
+                             <div class="service-description">
+                                  <h3>Building APIs on Rails 5 with AMS</h3>
+                                  <p>
+                                  A lot of people have being using Rails to develop both their internal or external API, but building a high quality API can be hard....
+                                  </p>
+                             </div>
+                             <div class="service-more">
+                                  <a href="#building-apis-rails-5"><h3>More Info</h3></a>
+                                  <a href="https://plus.google.com/events/cm0vmbq6bdcif7sitba8qv5rscc" target="_blank" class="call-to-button scroll">Click to Watch</a>
                              </div>
                         </div>
 
@@ -439,27 +439,6 @@
   </div>
 </div>
 
-<div class="remodal" data-remodal-id="building-apis-rails-5">
-  <button data-remodal-action="close" class="remodal-close"></button>
-  <div>
-    <h3>Building APIs on Rails 5 with AMS</h3>
-    <div>
-      <p>
-        A lot of people have being using Rails to develop both their internal or external API, but building a high quality API can be hard, and performance is a key point to achieve it.
-        I'll share my stories with APIs, and tell you how Active Model Serializer, component of Rails-API, helped me. AMS have being used across thousands of applications bringing convention over configuration to JSON generation.
-        This talk will give you a sneak peek of a new version of AMS that we have being working on, it's new cache conventions, and how it's being considered to be shipped by default in new Rails 5.
-
-			<p><b><a href="https://plus.google.com/events/cm0vmbq6bdcif7sitba8qv5rscc" target="_blank">Click to Watch</a></b></p>
-
-			<p>
-        <b>Speaker:</b> <a href="https://github.com/joaomdmoura" target="_blank">João Moura</a><br/>
-      </p>
-
-      </p>
-    </div>
-  </div>
-</div>
-
 <div class="remodal" data-remodal-id="intro-frp-elm">
   <button data-remodal-action="close" class="remodal-close"></button>
   <div>
@@ -480,6 +459,26 @@
   </div>
 </div>
 
+<div class="remodal" data-remodal-id="building-apis-rails-5">
+  <button data-remodal-action="close" class="remodal-close"></button>
+  <div>
+    <h3>Building APIs on Rails 5 with AMS</h3>
+    <div>
+      <p>
+        A lot of people have being using Rails to develop both their internal or external API, but building a high quality API can be hard, and performance is a key point to achieve it.
+        I'll share my stories with APIs, and tell you how Active Model Serializer, component of Rails-API, helped me. AMS have being used across thousands of applications bringing convention over configuration to JSON generation.
+        This talk will give you a sneak peek of a new version of AMS that we have being working on, it's new cache conventions, and how it's being considered to be shipped by default in new Rails 5.
+
+			<p><b><a href="https://plus.google.com/events/cm0vmbq6bdcif7sitba8qv5rscc" target="_blank">Click to Watch</a></b></p>
+
+			<p>
+        <b>Speaker:</b> <a href="https://github.com/joaomdmoura" target="_blank">João Moura</a><br/>
+      </p>
+
+      </p>
+    </div>
+  </div>
+</div>
 
 <!-- Separator Line -->
 <div class="separator-line"></div>


### PR DESCRIPTION
Not sure if y'all agree, but since we had the functional talk before the AMS one, I think this order would be better.

In other words, ordered by talk date, instead of "agreement date".